### PR TITLE
feat: implement multi-LLM configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,33 +44,41 @@ Une application de bureau complète pour préparer, analyser et interagir avec v
     pip install -r requirements.txt
     ```
 3.  **Configuration Essentielle** :
-    Copiez `config.ini.template` vers `config.ini` et configurez-le. Pour utiliser la Toolbox, la section `[LLMServer]` est requise :
+    Copiez `config.ini.template` vers `config.ini` et configurez-le. L'application supporte maintenant **plusieurs modèles LLM indépendants** que vous pouvez sélectionner directement depuis l'interface :
+    
     ```ini
-    [LLMServer]
-    # URL de l'API de votre LLM.
-    # Ex: https://api.openai.com/v1 ou http://localhost:11434 pour Ollama
-    url = YOUR_LLM_API_URL_HERE
+    # Chaque section [LLM:nom] définit un modèle indépendant
+    # Le nom après "LLM:" apparaîtra dans le sélecteur de l'interface
     
-    # Votre clé API (requise pour OpenAI, non nécessaire pour Ollama local)
-    apikey = YOUR_LLM_API_KEY_HERE
-    
-    # Modèle à utiliser
-    # Ex: gpt-4-turbo-preview, gpt-3.5-turbo, llama3, codellama
-    model = YOUR_LLM_MODEL_HERE
-    
-    # Type d'API : 'openai' ou 'ollama'
+    [LLM:GPT-4o]
+    url = https://api.openai.com/v1
+    apikey = YOUR_OPENAI_API_KEY_HERE
+    model = gpt-4o
     api_type = openai
-    
-    # Activer l'intégration LLM dans la Toolbox
-    enabled = true
-    
-    # Activer le streaming des réponses pour le chat
+    enabled = true  # Mettre à true pour activer ce modèle
     stream_response = true
+    ssl_verify = true
+    timeout_seconds = 300
+    temperature = 0.7
+    max_tokens = 4096
+    default = true  # Ce modèle sera sélectionné par défaut
     
-    # Paramètres optionnels pour contrôler la génération (décommentez si nécessaire)
-    # temperature = 0.7  # Contrôle la créativité (0.0 = déterministe, 1.0 = très créatif)
-    # max_tokens = 4096  # Nombre maximum de tokens pour la réponse
+    [LLM:Ollama Local]
+    url = http://localhost:11434
+    apikey =  # Pas de clé API pour Ollama local
+    model = llama3:70b
+    api_type = ollama
+    enabled = true
+    stream_response = false
+    ssl_verify = false
+    timeout_seconds = 600
     ```
+    
+    **Nouvelles fonctionnalités :**
+    - **Multi-modèles** : Configurez autant de modèles que nécessaire
+    - **Sélecteur dans l'interface** : Changez de modèle à la volée sans redémarrer
+    - **Configuration indépendante** : Chaque modèle a ses propres paramètres
+    - **Persistance du choix** : Le modèle sélectionné est mémorisé entre les sessions
 4.  Lancez l'application en double-cliquant sur **`run.bat`**.
 
 ## 🚀 Guide d'Utilisation

--- a/config.ini.template
+++ b/config.ini.template
@@ -6,18 +6,70 @@ debug = false
 instruction1_text = Ne fais rien, attends mes instructions.
 instruction2_text = Si des modifications du code source est nécessaire, tu dois présenter ta réponse sous la forme d'un fichier patch Linux. Considère que le fichier patch a été lancé depuis le répertoire du code-to-llm.
 
-[LLMServer]
-url = YOUR_LLM_API_URL_HERE
-apikey = YOUR_LLM_API_KEY_HERE
-model = YOUR_LLM_MODEL_HERE
-api_type = openai # Can be 'openai' or 'ollama'
+# Configuration multi-modèles LLM
+# Chaque section [LLM:nom] définit un modèle complètement indépendant
+# Le nom après "LLM:" sera affiché dans le sélecteur de l'interface
+
+[LLM:GPT-4o]
+url = https://api.openai.com/v1
+apikey = YOUR_OPENAI_API_KEY_HERE
+model = gpt-4o
+api_type = openai
 enabled = false
 stream_response = true
-ssl_verify = true # Set to false to disable SSL certificate verification (use with caution)
-timeout_seconds = 300 # Timeout in seconds for LLM API requests (default: 300)
-# Paramètres optionnels pour contrôler la génération
-# temperature = 0.7  # Contrôle la créativité (0.0 = déterministe, 1.0 = très créatif)
-# max_tokens = 4096  # Nombre maximum de tokens pour la réponse
+ssl_verify = true
+timeout_seconds = 300
+# Contrôle la créativité (0.0 = déterministe, 1.0 = très créatif)
+temperature = 0.7
+# Nombre maximum de tokens pour la réponse
+# Commentez cette ligne pour laisser le modèle utiliser son maximum par défaut
+# Pour Gemini 2.0 Flash : max 8192 tokens en output
+# max_tokens = 8192
+# Ce modèle sera sélectionné par défaut au démarrage
+default = true
+
+[LLM:Claude 3.5 Sonnet]
+url = https://api.anthropic.com/v1
+apikey = YOUR_ANTHROPIC_API_KEY_HERE
+model = claude-3-5-sonnet-20241022
+# ou 'openai' si utilisation via proxy OpenAI-compatible
+api_type = anthropic
+enabled = false
+stream_response = true
+ssl_verify = true
+timeout_seconds = 300
+temperature = 0.5
+# Claude peut générer jusqu'à 8192 tokens
+# max_tokens = 8192
+default = false
+
+[LLM:Ollama Local]
+url = http://localhost:11434
+# Pas de clé API pour Ollama local
+apikey =
+model = llama3:70b
+api_type = ollama
+enabled = false
+# Peut être désactivé pour certains modèles
+stream_response = false
+# Pas de SSL pour une connexion locale
+ssl_verify = false
+# Timeout plus long pour les modèles locaux
+timeout_seconds = 600
+temperature = 0.8
+# Laissez commenté pour utiliser le maximum du modèle
+# max_tokens = 4096
+
+# Ancienne configuration (conservée pour compatibilité, sera ignorée si des sections [LLM:*] existent)
+# [LLMServer]
+# url = YOUR_LLM_API_URL_HERE
+# apikey = YOUR_LLM_API_KEY_HERE
+# model = YOUR_LLM_MODEL_HERE
+# api_type = openai
+# enabled = false
+# stream_response = true
+# ssl_verify = true
+# timeout_seconds = 300
 
 [SummarizerLLM]
 # LLM pour le RESUME du code (compression "lossy")

--- a/templates/toolbox.html
+++ b/templates/toolbox.html
@@ -414,8 +414,18 @@
                         <div id="llm-error-chat" class="alert alert-danger p-2 d-none mb-3" role="alert" style="font-size: 0.9em;"></div>
                         
                         <div class="d-flex justify-content-between align-items-center mb-2">
-                            <div id="chat-info-bar" class="text-muted small api-mode-only">
-                                Tokens de la conversation : <span id="chat-token-count" class="fw-bold">0</span>
+                            <div class="d-flex align-items-center gap-3">
+                                <div id="chat-info-bar" class="text-muted small api-mode-only">
+                                    Tokens de la conversation : <span id="chat-token-count" class="fw-bold">0</span>
+                                </div>
+                                
+                                <!-- Sélecteur de LLM -->
+                                <div class="d-flex align-items-center api-mode-only">
+                                    <label for="llmSelector" class="form-label-sm me-2 mb-0 text-muted">Modèle:</label>
+                                    <select class="form-select form-select-sm" id="llmSelector" style="width: auto;" title="Choisir le modèle LLM à utiliser">
+                                        <!-- Options chargées dynamiquement -->
+                                    </select>
+                                </div>
                             </div>
                             
                             <!-- Barre de contrôle de navigation -->


### PR DESCRIPTION
- Add support for multiple independent LLM configurations
- Each model defined in its own [LLM:name] section
- Add model selector dropdown in Toolbox interface
- Support dynamic model switching without restart
- Persist user's model selection in localStorage
- Make API stateless by passing llm_id with each request
- Support 'enabled' flag to show/hide models
- Support 'default' flag for initial model selection
- Maintain backward compatibility with legacy [LLMServer] config
- Update web_server.py to detect new multi-model configuration
- Fix max_tokens parameter to use reasonable defaults
- Update documentation and tests

Breaking change: Configuration format changed from single [LLMServer] to multiple [LLM:ModelName] sections. Users need to update their config.ini files to the new format.